### PR TITLE
管理者登録後の画面遷移先を「従業員一覧」⇒「ログイン画面」に修正

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "administrator/login";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "administrator/login";
+		return "redirect:/login";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,14 +77,14 @@ public class AdministratorController {
 		if(result.hasErrors()) {
 			return toInsert();
 		}
+		if(form.getMailAddress() != null) {
+			model.addAttribute("errorMessage", "このメールアドレスは既に登録されています。");
+			return toInsert();
+		}
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		if(form.getMailAddress().equals(administrator.getMailAddress())) {
-			model.addAttribute("errorMessage", "このメールアドレスは既に登録されています。");
-			return toInsert();
-		}
 		return "redirect:/";
 	}
 

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		if(result.hasErrors()) {
 			return toInsert();
 		}
-		if(form.getMailAddress() != null) {
+		if(administratorService.findByMailAddress(form.getMailAddress()) != null) {
 			model.addAttribute("errorMessage", "このメールアドレスは既に登録されています。");
 			return toInsert();
 		}

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -81,7 +81,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "redirect:/login";
+		return toLogin();
 	}
 
 	/////////////////////////////////////////////////////
@@ -113,7 +113,7 @@ public class AdministratorController {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
-		return "redirect:/";
+		return "employee/list";
 	}
 	
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -73,7 +73,7 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@RequestMapping("/insert")
-	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result, Model model) {
 		if(result.hasErrors()) {
 			return toInsert();
 		}
@@ -81,7 +81,11 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return toLogin();
+		if(form.getMailAddress().equals(administrator.getMailAddress())) {
+			model.addAttribute("errorMessage", "このメールアドレスは既に登録されています。");
+			return toInsert();
+		}
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////
@@ -113,7 +117,7 @@ public class AdministratorController {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
-		return "employee/list";
+		return "forward:/employee/showList";
 	}
 	
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -72,7 +73,10 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@RequestMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if(result.hasErrors()) {
+			return toInsert();
+		}
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
@@ -103,13 +107,13 @@ public class AdministratorController {
 	 * @return ログイン後の従業員一覧画面
 	 */
 	@RequestMapping("/login")
-	public String login(LoginForm form, BindingResult result, Model model) {
+	public String login(@Validated LoginForm form, BindingResult result, Model model) {
 		Administrator administrator = administratorService.login(form.getMailAddress(), form.getPassword());
 		if (administrator == null) {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
-		return "forward:/employee/showList";
+		return "redirect:/";
 	}
 	
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
+++ b/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
@@ -1,5 +1,9 @@
 package jp.co.sample.emp_management.form;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +12,15 @@ package jp.co.sample.emp_management.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message="名前を入力してください")
 	private String name;
 	/** メールアドレス */
+	@NotBlank(message="メールアドレスを入力してください")
+	@Email(message="メールアドレスの値が不正です")
 	private String mailAddress;
 	/** パスワード */
+	@NotBlank(message="パスワードを入力してください")
+	@Size(min=8, message="８文字以上で入力してください")
 	private String password;
 
 	/**

--- a/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
+++ b/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
@@ -29,6 +29,10 @@ public class AdministratorService {
 		administratorRepository.insert(administrator);
 	}
 	
+	public Administrator findByMailAddress(String mailAddress) {
+		return administratorRepository.findByMailAddress(mailAddress);
+	}
+	
 	/**
 	 * ログインをします.
 	 * @param mailAddress メールアドレス

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -59,6 +59,7 @@
 										<label th:if="${#fields.hasErrors('mailAddress')}" th:errors="*{mailAddress}" class="error-messages">
 											メールアドレスを入力してください
 										</label>
+										<label th:if="${errorMessage != null}" th:text="${errorMessage}" class="error-messages"></label>
 										<input type="text" name="mailAddress" id="mailAddress" class="form-control" placeholder="yamada@mail.com"
 											 th:field="*{mailAddress}" th:errorclass="error-input" value="yamada@mail.com">
 									</div>


### PR DESCRIPTION
(1-1)初級 画面遷移
管理者登録後の画面遷移先を「従業員一覧」から「ログイン画面」に修正しました。